### PR TITLE
Python support

### DIFF
--- a/resource_appengine.go
+++ b/resource_appengine.go
@@ -101,6 +101,17 @@ func resourceAppengine() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"scriptName": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"pythonUrlRegex": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"servingStatus": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -113,43 +124,56 @@ var (
 	remoteBase = "https://storage.googleapis.com/"
 )
 
+func pythonUrlHandlers(d *schema.ResourceData) ([]*appengine.UrlMap) {
+	handlers := make([]*appengine.UrlMap, 0)
+	handlers = append(handlers, &appengine.UrlMap{
+		SecurityLevel: "SECURE_OPTIONAL",
+		Login: "LOGIN_OPTIONAL",
+		UrlRegex:d.Get("pythonUrlRegex").(string), 
+		Script:&appengine.ScriptHandler{
+			ScriptPath:d.Get("scriptName").(string),
+		},
+	})
+		
+	return handlers
+}
 
 func urlHandlers() ([]*appengine.UrlMap) {
 	handlers := make([]*appengine.UrlMap, 0)
-		handlers = append(handlers, &appengine.UrlMap{
-			SecurityLevel: "SECURE_OPTIONAL",
-			Login: "LOGIN_OPTIONAL",
-			UrlRegex:"/", 
-			Script:&appengine.ScriptHandler{
-				ScriptPath:"unused",
-			},
-		})
-		handlers = append(handlers, &appengine.UrlMap{
-			SecurityLevel: "SECURE_OPTIONAL",
-			Login: "LOGIN_OPTIONAL",
-			UrlRegex:"/.*/", 
-			Script:&appengine.ScriptHandler{
-				ScriptPath:"unused",
-			},
-		})
-		handlers = append(handlers, &appengine.UrlMap{
-			SecurityLevel: "SECURE_OPTIONAL",
-			Login: "LOGIN_OPTIONAL",
-			UrlRegex:"/_ah/.*", 
-			Script:&appengine.ScriptHandler{
-				ScriptPath:"unused",
-			},
-		})
-		handlers = append(handlers, &appengine.UrlMap{
-			SecurityLevel: "SECURE_OPTIONAL",
-			Login: "LOGIN_OPTIONAL",
-			UrlRegex:"/endpoint", 
-			Script:&appengine.ScriptHandler{
-				ScriptPath:"unused",
-			},
-		})
+	handlers = append(handlers, &appengine.UrlMap{
+		SecurityLevel: "SECURE_OPTIONAL",
+		Login: "LOGIN_OPTIONAL",
+		UrlRegex:"/", 
+		Script:&appengine.ScriptHandler{
+			ScriptPath:"unused",
+		},
+	})
+	handlers = append(handlers, &appengine.UrlMap{
+		SecurityLevel: "SECURE_OPTIONAL",
+		Login: "LOGIN_OPTIONAL",
+		UrlRegex:"/.*/", 
+		Script:&appengine.ScriptHandler{
+			ScriptPath:"unused",
+		},
+	})
+	handlers = append(handlers, &appengine.UrlMap{
+		SecurityLevel: "SECURE_OPTIONAL",
+		Login: "LOGIN_OPTIONAL",
+		UrlRegex:"/_ah/.*", 
+		Script:&appengine.ScriptHandler{
+			ScriptPath:"unused",
+		},
+	})
+	handlers = append(handlers, &appengine.UrlMap{
+		SecurityLevel: "SECURE_OPTIONAL",
+		Login: "LOGIN_OPTIONAL",
+		UrlRegex:"/endpoint", 
+		Script:&appengine.ScriptHandler{
+			ScriptPath:"unused",
+		},
+	})
 		
-		return handlers
+	return handlers
 }
 
 
@@ -172,13 +196,30 @@ func generateFileList(d *schema.ResourceData, config *Config) (map[string]appeng
 	}
 	
 	files := make(map[string]appengine.FileInfo)
+	
+	//  when NextPageToken is empty string, on last page
+	for objs.NextPageToken != "" {
+		files = objsToFilelist(objs, files, key, bucket)
+		listCall.PageToken(objs.NextPageToken)
+		objs, err = listCall.Do()
+		if err != nil {
+			return nil, err
+		}
+	}
+	
+	//  read contents of last page
+	files = objsToFilelist(objs, files, key, bucket)
+	
+	return files, nil
+}
+
+func objsToFilelist(objs *storage.Objects, files map[string]appengine.FileInfo, key, bucket string) (map[string]appengine.FileInfo) {
 	for _, obj := range objs.Items {
 		onDiskName := strings.Replace(obj.Name, key, "", 1)  // trims key from file name
 		inCloudURL := remoteBase + bucket + "/" + obj.Name
-		files[onDiskName] = appengine.FileInfo{SourceUrl:inCloudURL} 
+		files[onDiskName] = appengine.FileInfo{SourceUrl:inCloudURL}
 	}
-	
-	return files, nil
+	return files
 }
 
 func validateLatency(latency string) (string, error) {
@@ -252,6 +293,8 @@ func resourceAppengineCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.Get("runtime").(string) == "java7" {
 		version.Handlers = urlHandlers()
+	} else {
+		version.Handlers = pythonUrlHandlers(d)
 	}
 	
 	//  create the application

--- a/resource_appengine_test.go
+++ b/resource_appengine_test.go
@@ -25,6 +25,23 @@ func TestAccAppengineCreate(t *testing.T) {
 	})
 }
 
+func TestAccPythonAppengineCreate(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppengineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAppenginePython,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAppengineExists("googleappengine_app.foobar"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAppengineDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "googleappengine_app" {
@@ -79,13 +96,15 @@ resource "googleappengine_app" "foobar" {
 	topicName = "projects/hx-test/topics/notarealtopic"
 }`
 
-/*const testAccAppenginePython = `
+const testAccAppenginePython = `
 resource "googleappengine_app" "foobar" {
 	moduleName = "foobar"
 	version = "foobaz"
 	gstorageBucket = "build-artifacts-public-eu"
 	gstorageKey = "python-test-app/"
 	runtime = "python27"
+	scriptName = "guestbook.app"
+	pythonUrlRegex = "/.*"
 	
 	scaling {
 		minIdleInstances = 1
@@ -95,4 +114,4 @@ resource "googleappengine_app" "foobar" {
 	}
 	
 	topicName = "projects/hx-test/topics/notarealtopic"
-}`*/
+}`

--- a/resource_appengine_test.go
+++ b/resource_appengine_test.go
@@ -67,6 +67,7 @@ resource "googleappengine_app" "foobar" {
 	version = "foobaz"
 	gstorageBucket = "build-artifacts-public-eu"
 	gstorageKey = "hxtest-1.0-SNAPSHOT/"
+	runtime = "java7"
 	
 	scaling {
 		minIdleInstances = 1
@@ -77,3 +78,21 @@ resource "googleappengine_app" "foobar" {
 	
 	topicName = "projects/hx-test/topics/notarealtopic"
 }`
+
+/*const testAccAppenginePython = `
+resource "googleappengine_app" "foobar" {
+	moduleName = "foobar"
+	version = "foobaz"
+	gstorageBucket = "build-artifacts-public-eu"
+	gstorageKey = "python-test-app/"
+	runtime = "python27"
+	
+	scaling {
+		minIdleInstances = 1
+		maxIdleInstances = 3
+		minPendingLatency = "1s"
+		maxPendingLatency = "10s"
+	}
+	
+	topicName = "projects/hx-test/topics/notarealtopic"
+}`*/


### PR DESCRIPTION
adds limited python support to this provider.  python app must be staged in google cloud, have all third party deps installed to a folder named lib/ in the root of the project (pure python only) and have appengine_config.py configured to load deps from lib/

also only supports one endpoint per python application right now
